### PR TITLE
Add hashid template function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.23.3
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
+	github.com/goliatone/hashid v0.0.6
 	github.com/stretchr/testify v1.9.0
 	github.com/uptrace/bun v1.2.6
 	github.com/uptrace/bun/dbfixture v1.2.6
@@ -37,5 +38,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.32.0 // indirect
 	go.opentelemetry.io/otel/trace v1.32.0 // indirect
 	golang.org/x/sys v0.27.0 // indirect
+	golang.org/x/text v0.19.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23
 toolchain go1.23.3
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/stretchr/testify v1.9.0
 	github.com/uptrace/bun v1.2.6
 	github.com/uptrace/bun/dbfixture v1.2.6
@@ -14,7 +15,6 @@ require (
 )
 
 require (
-	github.com/DATA-DOG/go-sqlmock v1.5.2 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
+github.com/goliatone/hashid v0.0.6 h1:0nBOWrhrC1R4UBHVQ3PhP4Ono8CwmIae2tjolbpbSx0=
+github.com/goliatone/hashid v0.0.6/go.mod h1:hFnpJK2xQuq3V0ZRcenTsiYoTAO2zD524T9blFHSmtw=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
@@ -68,6 +70,8 @@ golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.27.0 h1:wBqf8DvsY9Y/2P8gAfPDEYNuS30J4lPHJxXSb/nJZ+s=
 golang.org/x/sys v0.27.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/text v0.19.0 h1:kTxAhCbGbxhK0IwgSKiMO5awPoDQ0RpfiVYBfK860YM=
+golang.org/x/text v0.19.0/go.mod h1:BuEKDfySbSR4drPmRPG/7iBdf8hvFMuRexcpahXilzY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/init_test.go
+++ b/init_test.go
@@ -56,6 +56,7 @@ func TestNew(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 	defer db.Close()
+	defer resetInit()
 
 	// Setup mock expectations
 	mock.ExpectPing()
@@ -77,11 +78,18 @@ func TestNew(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func resetInit() {
+	bunDB = nil
+	modelsToRegister = []any{}
+}
+
 func TestRegisterModel(t *testing.T) {
 	type TestModel struct {
 		ID   int64 `bun:"id,pk,autoincrement"`
 		Name string
 	}
+
+	defer resetInit()
 
 	RegisterModel((*TestModel)(nil))
 
@@ -89,6 +97,8 @@ func TestRegisterModel(t *testing.T) {
 }
 
 func TestFixtures(t *testing.T) {
+	defer resetInit()
+
 	mockDB := bun.NewDB(new(sql.DB), pgdialect.New())
 	fixtures := NewSeedManager(mockDB)
 
@@ -123,6 +133,8 @@ func TestFixtures(t *testing.T) {
 }
 
 func TestMigrations(t *testing.T) {
+	defer resetInit()
+
 	ctx := context.Background()
 	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
@@ -165,6 +177,8 @@ func TestMigrations(t *testing.T) {
 }
 
 func TestClient(t *testing.T) {
+	defer resetInit()
+
 	db, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
 	assert.NoError(t, err)
 	defer db.Close()

--- a/taskfile
+++ b/taskfile
@@ -39,6 +39,16 @@ function _install:lgr {
     fi
 }
 
+function _install:changelog {
+    if git-cliff lgr 2>/dev/null; then
+        lgr OK "git-cliff already installed..."
+    else
+        echo "Installing lgr"
+        brew install brew install orhun/git-cliff/git-cliff
+        lgr OK "git-cliff installed..."
+    fi
+}
+
 function _install:brew {
     if [[ $(command -v brew) == "" ]]; then
         lgr I "Installing Hombrew"
@@ -70,6 +80,7 @@ function dev:install {
     _install:brew
 
     _install:envset
+    _install:changelog
 
     lgr ok "dependencies intalled..."
 }
@@ -77,7 +88,6 @@ function dev:install {
 function dev:env:load {
     eval "$(envset development --isolated=true)"
 }
-
 
 ##
 ## ########################################
@@ -159,22 +169,46 @@ function version:set {
 ## - minor
 ## - major
 ##
+## If you want to update the .version file
+## pass the `--write` flag.
 ## @see https://github.com/fsaintjacques/semver-tool/blob/master/src/semver
 ##
 ## @arg 1 {string} [level=patch]
 ## Outputs:
 ##   Semver string "$major.$minor.$patch"
+##
+## @flag --write Will write to .version file
+##
 function version:bump {
 
     version:check
+
+    # Default values
+    level='patch'
+    write_to_file=0
+
+    # Parse options
+    while [[ "$#" -gt 0 ]]; do
+        case $1 in
+            --write)
+                write_to_file=1
+                shift
+            ;;
+            patch|minor|major)
+                level=$1
+                shift
+            ;;
+            *)
+                echo "Invalid option: $1"
+                return 2
+            ;;
+        esac
+    done
 
     # Read contents of version and store in
     IFS='.' read -ra identifiers < "$VERSION_FILE"
 
     [[ "${#identifiers[@]}" -ne 3 ]] && echo "Invalid semver string" && return 1
-
-    #If we don't provide a second argument make patch increment
-    [[ "$#" -eq 0 ]] && level='patch' || level=$1
 
     patch=${identifiers[2]}
     minor=${identifiers[1]}
@@ -198,13 +232,74 @@ function version:bump {
             return 2
     esac
 
-    echo "$major.$minor.$patch"
+    new_version="$major.$minor.$patch"
+
+    if [[ $write_to_file -eq 1 ]]; then
+        echo "$new_version" > "${VERSION_FILE}"
+    else
+        echo "$new_version"
+    fi
 }
 
 function version:check {
     if [ ! -f "$VERSION_FILE" ]; then
         echo "0.0.0" > "$VERSION_FILE"
     fi
+}
+
+
+##
+## -----
+##
+## release
+##
+## Bump our current version, create a git tag
+## and push to trigger our release flow.
+##
+## Arguments:
+## @arg 1 {string} [level=patch]
+##        Accepted major, minor, patch
+function release {
+    local tag
+    local level
+    local message
+
+    # Fetch all changes from origin
+    git fetch --all
+    # Make sure we have the latest version file
+    git checkout origin/main -- ".version"
+
+    # Pull tags to make sure we have
+    git pull --tags -f
+
+    level=${1:-"patch"}
+
+    # Bump our version
+    tag=$(version:bump "${level}")
+
+    # Set message: default to New major|minor|patch release: vx.x.x
+    message=${2:-"New ${level} release: v${tag}"}
+
+    # Update version file
+    version:set "${tag}"
+
+    # Add updated version file to git
+    git add "${VERSION_FILE}"
+    git commit -m "Bump version: v${tag}"
+
+    # Create a new tag
+    git tag -a "v${tag}" -m "${message}"
+
+    # Push tags and trigger release 🚀 🥳
+    git push --tags
+    git push
+
+    # Generate changelog
+    git cliff --output CHANGELOG.md
+    git add CHANGELOG.md
+    git commit -m "docs: update changelog for v${tag}"
+
+    git push
 }
 
 ##########################################
@@ -228,7 +323,7 @@ function help {
 
     prog="$0"
     me=$(basename "$prog")
-    
+
     grep -e '^##[[:space:]]' -e '^##$' "$prog" | sed -e 's/^##//' -e "s/_PROG_/$me/" 2>&1 | less
 }
 


### PR DESCRIPTION
This PR adds `hashid` as a template function to fixtures, so you can create consistent UUIDs from known strings:
```yml
- model: Company
  rows:
    - id: '{{ hashid compay:acme-industries }}'
      name: ACME Inc
      namespace: acme
      updated_at: '{{ now }}'
- model: User
  rows:
    - id: '{{ hashid "contact:john-doe" }}'
      name: John Doe
      company_id: '{{ hashid compay:acme-industries }}'
```